### PR TITLE
Updated cookies to only expire after 4 years

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -24,7 +24,7 @@ export function Header(props) {
 
   const handleThemeChange = useCallback(() => {
     const newTheme = theme === 'light' ? 'dark' : 'light';
-    Cookies.set('theme', newTheme);
+    Cookies.set('theme', newTheme, { expires: 1460 });
     setTheme(newTheme);
   }, [theme, setTheme]);
 

--- a/src/hooks/useCookie.js
+++ b/src/hooks/useCookie.js
@@ -6,7 +6,7 @@ export function useCookie(key, defaultValue) {
 
   const setCookieValue = useCallback(value => {
     setValue(value);
-    Cookies.set(key, value);
+    Cookies.set(key, value, { expires: 1460 });
   }, [key, setValue]);
 
   useEffect(() => {


### PR DESCRIPTION
A recent update caused all cookies (and hence saved schedules) to be cleared when the browser is closed. I have added an explicit validity period to the cookies, which should keep the cookies active for 4 years from the time they are set.